### PR TITLE
Changed link to "Game.ini" from "Game.ini.txt" to "Game.ini"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ touch /home/steam/pavlovserver/Pavlov/Saved/Config/whitelist.txt
 
 nano /home/steam/pavlovserver/Pavlov/Saved/Config/LinuxServer/Game.ini
 ```
-> See https://github.com/Josephfallen/Pavlov_server_hosting/blob/main/Game.ini.txt for the file's contents
+> See https://github.com/Josephfallen/Pavlov_server_hosting/blob/main/Game.ini for the file's contents
 
 ## Logged Out of steam
 ```


### PR DESCRIPTION
Changed link to "Game.ini" from "Game.ini.txt" to "Game.ini" so the link in the README.md would no longer be broken